### PR TITLE
Fix: removing custom user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,15 +15,5 @@ ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
 # Puppeteer v1.9.0 works with Chromium 71.
 RUN yarn add puppeteer@1.9.0
 
-# Add user so we don't need --no-sandbox.
-RUN addgroup -S pptruser && adduser -S -g pptruser pptruser \
-    && mkdir -p /home/pptruser/Downloads \
-    && chown -R pptruser:pptruser /home/pptruser \
-    && mkdir -p /app \
-    && chown -R pptruser:pptruser /app
-
-# Run everything after as non-privileged user.
-USER pptruser
-
 ENTRYPOINT ["dumb-init", "--"]
 CMD ["google-chrome-unstable"]


### PR DESCRIPTION
I had this error in my drone step using this image:
`/bin/sh: can't create /root/.netrc: Permission denied`

Searching a bit I've found out that drone only uses root to write files in the container
https://discourse.drone.io/t/solved-netrc-permission-denied/171/2

That's why I removed the custom user `pptruser`