### PR TITLE
Moving to node:10.15.0 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-alpine
+FROM node:10.15.0
 
 # Installs latest Chromium (71) package.
 RUN apk update && apk upgrade && \


### PR DESCRIPTION
Moving to `node:10.15.0` image instead of `node:alpine` due problems we were facing with the C libraries. `alpine` versions use `musl` intead of `glibc`. :(